### PR TITLE
feat: add incremental_overlap_seconds parameter for watermark safety margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ It can override the table name with the parameter **output_table_name** and the 
 Incremental fetching allows the fetching of only the records that have been modified since the previous run of
 the component. This is done by specifying an incremental field in the object that contains data on when it wast last modified.
 
+#### Incremental Overlap
+
+To prevent missing records due to clock skew or delayed commits in distributed systems, you can configure an overlap period using the `incremental_overlap_seconds` parameter. When set, this parameter subtracts the specified number of seconds from the last watermark, ensuring that records near the boundary are re-fetched.
+
+**Note:** When using overlap, duplicate records may be fetched. However, since incremental mode is configured with a primary key, duplicates will be automatically deduplicated during the loading process.
 
 **Example: With Security Token**
 
@@ -126,7 +131,8 @@ the component. This is done by specifying an incremental field in the object tha
         "Id"
       ],
       "incremental_field": "lastmodifieddate",
-      "incremental_fetch": true
+      "incremental_fetch": true,
+      "incremental_overlap_seconds": 60
     }
   }
 }

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -157,6 +157,20 @@
             }
           }
         },
+        "incremental_overlap_seconds": {
+          "title": "Incremental Overlap (seconds)",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "description": "Number of seconds to subtract from the last watermark to prevent missing records due to clock skew or delayed commits. Default is 0 (no overlap).",
+          "propertyOrder": 350,
+          "options": {
+            "dependencies": {
+              "incremental": 1,
+              "incremental_fetch": true
+            }
+          }
+        },
         "incremental": {
           "type": "integer",
           "enum": [


### PR DESCRIPTION
# feat: add incremental_overlap_seconds parameter for watermark safety margin

## Summary
This PR adds a new optional configuration parameter `incremental_overlap_seconds` to address the issue of potentially missing records in incremental fetches when using SystemModstamp or similar timestamp fields.

**Problem:** Records that are modified very close to the watermark timestamp boundary may be missed between consecutive runs due to clock skew, delayed commits in distributed systems, or race conditions.

**Solution:** The new parameter allows users to configure a "safety overlap" period in seconds. When set, the extractor subtracts this value from the last watermark before querying Salesforce, ensuring records near the boundary are re-fetched.

**Changes:**
- Added `incremental_overlap_seconds` parameter to `configRowSchema.json` (integer, default: 0, minimum: 0)
- Modified `_build_soql_query()` to apply the overlap by subtracting seconds from the watermark timestamp
- Updated README.md with documentation and usage example
- Added logging when overlap is applied for transparency

**Backward Compatibility:** The default value is 0, so existing configurations will continue to work exactly as before with no behavior change.

## Review & Testing Checklist for Human

This is a **YELLOW risk** change - minimal code complexity but untested end-to-end with actual Salesforce data.

- [ ] **Verify timestamp format assumption**: Confirm that the state file's `last_run` value is always in the format `%Y-%m-%dT%H:%M:%S.%fZ` (e.g., `2025-10-16T10:00:00.000Z`). The parsing logic depends on this.
- [ ] **Test with actual Salesforce incremental config**: Run the extractor with `incremental_overlap_seconds: 60` on a real configuration and verify:
  - The adjusted watermark is logged correctly
  - Records within the overlap period are re-fetched
  - Duplicate records are properly deduplicated by primary key
- [ ] **Verify backward compatibility**: Test an existing incremental configuration WITHOUT the new parameter to ensure behavior is unchanged
- [ ] **Check edge cases**: 
  - What happens if overlap is longer than the time between runs?
  - Verify the UI correctly shows/hides the field based on dependencies (incremental=1, incremental_fetch=true)

### Test Plan
1. Set up a Salesforce incremental extraction with SystemModstamp or LastModifiedDate
2. Run once to establish a watermark
3. Add `incremental_overlap_seconds: 60` to the configuration
4. Run again and check logs for "Applying incremental overlap" message
5. Verify that records with timestamps within 60 seconds of the previous watermark are re-fetched

### Notes
- The code handles timestamp parsing errors gracefully by falling back to the original watermark
- Duplicate records from overlap will be deduplicated automatically since incremental mode requires a primary key
- Session: https://app.devin.ai/sessions/6f20e942b9004c6b8b2972658da68f5e
- Requested by: zdenek.srotyr@keboola.com (@ZdenekSrotyr)