### PR TITLE
feat: add incremental_overlap_seconds parameter for watermark safety margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ It can override the table name with the parameter **output_table_name** and the 
 Incremental fetching allows the fetching of only the records that have been modified since the previous run of
 the component. This is done by specifying an incremental field in the object that contains data on when it wast last modified.
 
+#### Incremental Overlap
+
+To prevent missing records due to clock skew or delayed commits in distributed systems, you can configure an overlap period using the `incremental_overlap_seconds` parameter. When set, this parameter subtracts the specified number of seconds from the last watermark, ensuring that records near the boundary are re-fetched.
+
+**Note:** When using overlap, duplicate records may be fetched. However, since incremental mode is configured with a primary key, duplicates will be automatically deduplicated during the loading process.
 
 **Example: With Security Token**
 
@@ -126,7 +131,8 @@ the component. This is done by specifying an incremental field in the object tha
         "Id"
       ],
       "incremental_field": "lastmodifieddate",
-      "incremental_fetch": true
+      "incremental_fetch": true,
+      "incremental_overlap_seconds": 60
     }
   }
 }

--- a/component_config/configRowSchema.json
+++ b/component_config/configRowSchema.json
@@ -157,6 +157,20 @@
             }
           }
         },
+        "incremental_overlap_seconds": {
+          "title": "Incremental Overlap (seconds)",
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "description": "Number of seconds to subtract from the last watermark to prevent missing records due to clock skew or delayed commits. Default is 0 (no overlap).",
+          "propertyOrder": 350,
+          "options": {
+            "dependencies": {
+              "incremental": 1,
+              "incremental_fetch": true
+            }
+          }
+        },
         "incremental": {
           "type": "integer",
           "enum": [


### PR DESCRIPTION
# Add incremental_overlap_seconds parameter

Fixes SUPPORT-13828

## Problem
Records modified near the watermark boundary may be missed between incremental runs due to clock skew or delayed commits.

## Solution
New optional parameter `incremental_overlap_seconds` (default: 0) subtracts specified seconds from the last watermark to ensure records near the boundary are re-fetched.

**Example:**
- Last watermark: `2025-10-16T10:00:00.000Z`
- With overlap 60s: query uses `2025-10-16T09:59:00.000Z`
- Duplicates are auto-deduplicated by primary key

## Changes
- Added `incremental_overlap_seconds` to config schema
- Modified watermark logic in `_build_soql_query()`
- Updated README with documentation

**Backward compatible:** Default value 0 preserves existing behavior.

---
Link to Devin run: https://app.devin.ai/sessions/6f20e942b9004c6b8b2972658da68f5e
Requested by: @ZdenekSrotyr
