### PR TITLE
feat: add get_agent_context() for KAI agent integration

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,12 +1,10 @@
 name: Keboola Component Build & Deploy Pipeline
 on:
-  push:
-    branches:
-      - 'feature/*'
-      - 'bug/*'
-      - 'devin/*'
+  push:  # skip the workflow on the main branch without tags
+    branches-ignore:
+      - main
     tags:
-      - '*' # Skip the workflow on the main branch without tags
+      - '*'
 
 concurrency: ci-${{ github.ref }} # to avoid tag collisions in the ECR
 env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'feature/*'
       - 'bug/*'
+      - 'devin/*'
     tags:
       - '*' # Skip the workflow on the main branch without tags
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.13-slim
 
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
+
 RUN pip install flake8
 
 COPY requirements.txt /code/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backoff==2.2.1; python_version >= '3.7' and python_version < '4.0'
 freezegun==1.5.1; python_version >= '3.7'
-keboola.component==1.6.10; python_version >= '3.7'
+keboola.component @ git+https://github.com/keboola/python-component.git@devin/1770659076-agent-schema-agent-code; python_version >= '3.7'
 keboola.http-client==1.0.1; python_version >= '3.7'
 keboola.utils==1.1.0; python_version >= '3.7'
 mock==5.1.0; python_version >= '3.6'

--- a/src/component.py
+++ b/src/component.py
@@ -690,6 +690,11 @@ class Component(ComponentBase):
 
         return [SelectElement(label=column, value=column_values[i]) for i, column in enumerate(columns)]
 
+    def get_agent_context(self) -> dict:
+        params = self.configuration.parameters
+        sf_client = self.get_salesforce_client(params)
+        return {'sf': sf_client.simple_client}
+
     def _get_first_result_from_custom_soql(self) -> dict:
         params = self.configuration.parameters
         salesforce_client = self.get_salesforce_client(params)


### PR DESCRIPTION
## Summary

Adds `get_agent_context()` override to the Salesforce component, enabling KAI to execute arbitrary Python code against an authenticated Salesforce client via the new `agentCode` sync action (defined in the base library).

The method authenticates using the existing `get_salesforce_client()` flow and exposes the raw `simple_salesforce.Salesforce` object as `sf` in the agent code namespace.

**Depends on:** [keboola/python-component#90](https://github.com/keboola/python-component/pull/90) (adds `agentSchema`/`agentCode` sync actions to `ComponentBase`)

`requirements.txt` currently points to the feature branch of the base library — **must be updated to a released version before merge**.

## Updates since last revision

- **`push.yml` reworked to use `branches-ignore: main`** — replaced the explicit branch whitelist (`feature/*`, `bug/*`) with the `branches-ignore` pattern used by newer components (e.g. Acumatica). All branches now trigger CI except `main`.
- **`Dockerfile` installs `git`** — the `python:3.13-slim` base image lacks `git`, which is required for `pip install` to clone the git+https dependency in `requirements.txt`. This line can be removed once `requirements.txt` is updated to a released version of `keboola.component`.

## Review & Testing Checklist for Human

- [ ] **Do not merge until `python-component` PR #90 is merged and released** — `requirements.txt` pins to a git branch (`devin/1770659076-agent-schema-agent-code`) which will break if the branch is deleted. Update to a proper version pin before merging. Also revert the `git` install in `Dockerfile` at that point if no longer needed.
- [ ] **Confirm `branches-ignore: main` CI pattern is acceptable** — this is more permissive than the original `feature/*` + `bug/*` whitelist. It matches the pattern used by newer components (Acumatica), but means any branch push (not just `feature/` or `bug/`) will trigger CI. Verify this aligns with team conventions for this repo.
- [ ] **`get_agent_context()` re-authenticates on every call** — each `agentCode` invocation creates a new `SalesforceClient` and logs in. Verify this is acceptable for the sub-second latency goal, or consider whether the client should be cached on the component instance.
- [ ] **Schema generation triggers authentication** — the base class `_generate_agent_schema()` calls `get_agent_context()` to populate `context_variables`, meaning an `agentSchema` call will also authenticate to Salesforce. Confirm this is the desired behavior.
- [ ] **End-to-end test plan**: Register `agentSchema` and `agentCode` as sync actions in Developer Portal for this component. Run `agentSchema` to verify the generated schema includes Salesforce client methods. Then run `agentCode` with a snippet like `result = sf.query("SELECT Id, Name FROM Account LIMIT 1")["records"]` against a real config with credentials.

### Notes
- No unit tests added for `get_agent_context()` in this PR — the method is a 4-line delegation to existing tested code.
- Link to Devin run: https://app.devin.ai/sessions/dda90ce482014efa8ba751869407fdd4
- Requested by: @ZdenekSrotyr

## Release Notes
**Justification, description**

Adds `get_agent_context()` to the Salesforce component, enabling KAI agent integration via `agentSchema` and `agentCode` sync actions from the base library. CI workflow updated to `branches-ignore` pattern matching newer component conventions.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low — adds a new method to the component class with no effect on existing behavior. CI workflow change broadens branch triggers from whitelist to `branches-ignore: main`. Dockerfile temporarily includes `git` for the branch dependency.

**Deployment Plan**

Merge base library PR #90 first, update `requirements.txt` to released version, remove `git` from Dockerfile if no longer needed, then merge.

**Rollback Plan**

Revert commit and release previous version.


**Post-Release Support Plan**

N/A
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/component-salesforce-v2/pull/10" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
