### PR TITLE
Defensive fix: retry dropped connections instead of failing the job with an internal error

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -353,10 +353,10 @@ class Component(ComponentBase):
     # keeps propagating exactly as it did before.
     # One decorator over both exception types, never two stacked ones: nesting multiplies the budget, because an
     # inner run that ends in the outer decorator's exception is re-entered with a fresh inner budget, making the
-    # worst case tries x tries. Measured on an alternating connection/authentication sequence, two stacked
-    # decorators give 9 login attempts and 22 s of sleep, in either nesting order; this combined form has a hard
-    # 3-attempt cap. Cost on the sync actions users wait on interactively: an input that can never work takes
-    # 10 s of added sleep (2 retries x 5 s) before the same error reaches the UI.
+    # worst case tries x tries. Measured over mixed connection/authentication sequences, two stacked decorators
+    # reach 9 login attempts whichever way they are nested, up to 40 s of sleep in the worst ordering; this
+    # combined form has a hard 3-attempt cap. Cost on the sync actions users wait on interactively: an input that
+    # can never work takes 10 s of added sleep (2 retries x 5 s) before the same error reaches the UI.
     @retry((SalesforceAuthenticationFailed, RequestsConnectionError), tries=3, delay=5)
     def _login_to_salesforce(self, params: dict) -> SalesforceClient:
         login_method = self._get_login_method()

--- a/src/component.py
+++ b/src/component.py
@@ -349,7 +349,12 @@ class Component(ComponentBase):
 
     # The login request happens before the SalesforceClient exists, so it is not covered by the transport retries
     # mounted on the client session. A dropped connection is retried here and re-raised unchanged afterwards.
-    @retry((SalesforceAuthenticationFailed, RequestsConnectionError), tries=3, delay=5)
+    # The connection retry is a separate decorator so the authentication retry keeps its original timing. Stacking
+    # does not multiply attempts - each decorator catches only its own exception type, so a pure transport failure
+    # is still 3 calls. The shorter delay keeps the sync actions users wait on interactive: an input that can never
+    # work now costs 4 s of added sleep before the same error reaches the UI, not 10 s.
+    @retry(SalesforceAuthenticationFailed, tries=3, delay=5)
+    @retry(RequestsConnectionError, tries=3, delay=2)
     def _login_to_salesforce(self, params: dict) -> SalesforceClient:
         login_method = self._get_login_method()
 

--- a/src/component.py
+++ b/src/component.py
@@ -12,6 +12,7 @@ from keboola.component.dao import SupportedDataTypes, BaseType, ColumnDefinition
 from keboola.component.exceptions import UserException
 from keboola.component.sync_actions import MessageType, SelectElement, ValidationResult
 from keboola.utils.header_normalizer import NormalizerStrategy, get_normalizer
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from retry import retry
 from simple_salesforce.exceptions import SalesforceAuthenticationFailed, SalesforceError, SalesforceResourceNotFound
 
@@ -346,7 +347,9 @@ class Component(ComponentBase):
         except SalesforceAuthenticationFailed as e:
             raise UserException(f"Authentication Failed : recheck your authorization parameters : {e}") from e
 
-    @retry(SalesforceAuthenticationFailed, tries=3, delay=5)
+    # The login request happens before the SalesforceClient exists, so it is not covered by the transport retries
+    # mounted on the client session. A dropped connection is retried here and re-raised unchanged afterwards.
+    @retry((SalesforceAuthenticationFailed, RequestsConnectionError), tries=3, delay=5)
     def _login_to_salesforce(self, params: dict) -> SalesforceClient:
         login_method = self._get_login_method()
 

--- a/src/component.py
+++ b/src/component.py
@@ -348,13 +348,16 @@ class Component(ComponentBase):
             raise UserException(f"Authentication Failed : recheck your authorization parameters : {e}") from e
 
     # The login request happens before the SalesforceClient exists, so it is not covered by the transport retries
-    # mounted on the client session. A dropped connection is retried here and re-raised unchanged afterwards.
-    # The connection retry is a separate decorator so the authentication retry keeps its original timing. Stacking
-    # does not multiply attempts - each decorator catches only its own exception type, so a pure transport failure
-    # is still 3 calls. The shorter delay keeps the sync actions users wait on interactive: an input that can never
-    # work now costs 4 s of added sleep before the same error reaches the UI, not 10 s.
-    @retry(SalesforceAuthenticationFailed, tries=3, delay=5)
-    @retry(RequestsConnectionError, tries=3, delay=2)
+    # mounted on the client session. A dropped connection is retried here and re-raised unchanged afterwards -
+    # get_salesforce_client converts only SalesforceAuthenticationFailed into a UserException, so a transport failure
+    # keeps propagating exactly as it did before.
+    # One decorator over both exception types, never two stacked ones: nesting multiplies the budget, because an
+    # inner run that ends in the outer decorator's exception is re-entered with a fresh inner budget, making the
+    # worst case tries x tries. Measured on an alternating connection/authentication sequence, two stacked
+    # decorators give 9 login attempts and 22 s of sleep, in either nesting order; this combined form has a hard
+    # 3-attempt cap. Cost on the sync actions users wait on interactively: an input that can never work takes
+    # 10 s of added sleep (2 retries x 5 s) before the same error reaches the UI.
+    @retry((SalesforceAuthenticationFailed, RequestsConnectionError), tries=3, delay=5)
     def _login_to_salesforce(self, params: dict) -> SalesforceClient:
         login_method = self._get_login_method()
 

--- a/src/salesforce/client.py
+++ b/src/salesforce/client.py
@@ -38,8 +38,8 @@ MAX_RETRIES = 3
 
 # urllib3 does not wait before the first transport retry; from the second one it waits
 # TRANSPORT_RETRY_BACKOFF_FACTOR * 2 ** (n - 1) seconds. At factor 1 the sleeps are 0, 2 and 4 s, so a request that
-# ultimately fails takes about 6 s longer than it used to. The describe_object* backoff.expo wrapper retries the whole
-# call, so its own waits can stack on top of these.
+# ultimately fails takes about 6 s longer than it used to. This applies to the requests that go through the session
+# below; the describe_object* calls do not, so their backoff.expo waits never stack on top of these.
 TRANSPORT_RETRY_BACKOFF_FACTOR = 1
 
 

--- a/src/salesforce/client.py
+++ b/src/salesforce/client.py
@@ -36,7 +36,10 @@ DEFAULT_QUERY_PAGE_SIZE = 50000
 DEFAULT_API_VERSION = "52.0"
 MAX_RETRIES = 3
 
-# urllib3 waits TRANSPORT_RETRY_BACKOFF_FACTOR * 2 ** (attempt - 1) seconds between transport retries.
+# urllib3 does not wait before the first transport retry; from the second one it waits
+# TRANSPORT_RETRY_BACKOFF_FACTOR * 2 ** (n - 1) seconds. At factor 1 the sleeps are 0, 2 and 4 s, so a request that
+# ultimately fails takes about 6 s longer than it used to. The describe_object* backoff.expo wrapper retries the whole
+# call, so its own waits can stack on top of these.
 TRANSPORT_RETRY_BACKOFF_FACTOR = 1
 
 
@@ -101,10 +104,21 @@ class SalesforceClient(HttpClient):
 
         Salesforce occasionally closes a connection without answering, which reaches the component as
         requests.exceptions.ConnectionError("('Connection aborted.', RemoteDisconnected(...))") and kills the
-        whole job. Only transport failures are retried, and only for the idempotent methods urllib3 allows by
-        default. HTTP responses are never retried (status=0 and no status_forcelist), so every response the
-        component already handled - including error responses - is passed through untouched. Once the retries
-        are exhausted the original exception propagates exactly as before.
+        whole job. Only transport failures are retried. A failure after the request went out (urllib3's read
+        branch) is gated on allowed_methods, so a POST is never re-sent once Salesforce could have seen it;
+        connect-phase failures, which urllib3 raises only when the server provably never received the request,
+        are retried for every method.
+
+        No HTTP response is ever retried. That invariant is carried by three settings together: total=None makes
+        Retry.is_retry() short-circuit to False for every status, the empty status_forcelist with status=0 keeps
+        it False if total is ever given a number, and respect_retry_after_header=False closes the remaining path
+        where a 413/429/503 carrying Retry-After could be acted on. Every response the component already handled
+        - including error responses - is therefore passed through untouched.
+
+        Coverage is the pre-response phase inside HTTPAdapter.send only. A bulk result download dropped
+        mid-body surfaces out of iter_content as requests.exceptions.ChunkedEncodingError, which nothing retries
+        and which leaves a partial CSV in the output path - pre-existing behaviour, deliberately unchanged here.
+        Once the retries are exhausted the original exception propagates exactly as before.
         """
         retry = Retry(
             total=None,
@@ -112,6 +126,7 @@ class SalesforceClient(HttpClient):
             read=MAX_RETRIES,
             status=0,
             other=0,
+            respect_retry_after_header=False,
             backoff_factor=TRANSPORT_RETRY_BACKOFF_FACTOR,
         )
         adapter = HTTPAdapter(max_retries=retry)

--- a/src/salesforce/client.py
+++ b/src/salesforce/client.py
@@ -6,7 +6,10 @@ from typing import Any, Iterator
 from urllib.parse import urlparse
 
 import backoff
+import requests
 from keboola.http_client import HttpClient
+from requests.adapters import HTTPAdapter, Retry
+from requests.exceptions import ConnectionError as RequestsConnectionError
 from simple_salesforce.api import Salesforce, SFType
 from simple_salesforce.bulk2 import ColumnDelimiter, LineEnding, Operation, QueryResult, SFBulk2Type
 from simple_salesforce.exceptions import SalesforceBulkV2LoadError, SalesforceExpiredSession, SalesforceMalformedRequest
@@ -33,9 +36,19 @@ DEFAULT_QUERY_PAGE_SIZE = 50000
 DEFAULT_API_VERSION = "52.0"
 MAX_RETRIES = 3
 
+# urllib3 waits TRANSPORT_RETRY_BACKOFF_FACTOR * 2 ** (attempt - 1) seconds between transport retries.
+TRANSPORT_RETRY_BACKOFF_FACTOR = 1
+
 
 class SalesforceClientException(Exception):
     pass
+
+
+# Retried by the describe_object* methods. They talk to Salesforce through SFType, which builds its own requests
+# session, so _mount_transport_retries does not cover them; RequestsConnectionError is not a subclass of the
+# built-in ConnectionError they already catch either, so a dropped connection would otherwise kill the whole job.
+# After max_tries the original exception is re-raised unchanged.
+RETRIED_DESCRIBE_ERRORS = (SalesforceClientException, RequestsConnectionError)
 
 
 class SalesforceBulk2(SFBulk2Type):
@@ -80,6 +93,30 @@ class SalesforceClient(HttpClient):
         self.api_version = api_version
         self.host = urlparse(self.simple_client.base_url).hostname
         self.sessionId = self.simple_client.session_id
+        self._mount_transport_retries(self.simple_client.session)
+
+    @staticmethod
+    def _mount_transport_retries(session: requests.Session) -> None:
+        """Retries requests that never got a response because the connection was dropped.
+
+        Salesforce occasionally closes a connection without answering, which reaches the component as
+        requests.exceptions.ConnectionError("('Connection aborted.', RemoteDisconnected(...))") and kills the
+        whole job. Only transport failures are retried, and only for the idempotent methods urllib3 allows by
+        default. HTTP responses are never retried (status=0 and no status_forcelist), so every response the
+        component already handled - including error responses - is passed through untouched. Once the retries
+        are exhausted the original exception propagates exactly as before.
+        """
+        retry = Retry(
+            total=None,
+            connect=MAX_RETRIES,
+            read=MAX_RETRIES,
+            status=0,
+            other=0,
+            backoff_factor=TRANSPORT_RETRY_BACKOFF_FACTOR,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
 
     @classmethod
     def from_connected_app(cls, username: str, password: str, consumer_key: str, consumer_secret: str, sandbox: str,
@@ -110,7 +147,7 @@ class SalesforceClient(HttpClient):
 
         return cls(simple_client=simple_client, api_version=api_version)
 
-    @backoff.on_exception(backoff.expo, SalesforceClientException, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIED_DESCRIBE_ERRORS, max_tries=3)
     def describe_object(self, sf_object: str) -> list[str]:
         salesforce_type = SFType(sf_object, self.sessionId, self.host, sf_version=self.api_version)
 
@@ -121,7 +158,7 @@ class SalesforceClient(HttpClient):
 
         return [field['name'] for field in object_desc['fields'] if self.is_bulk_supported_field(field)]
 
-    @backoff.on_exception(backoff.expo, SalesforceClientException, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIED_DESCRIBE_ERRORS, max_tries=3)
     def describe_object_w_metadata(self, sf_object: str) -> list[tuple[str, str]]:
         salesforce_type = SFType(sf_object, self.sessionId, self.host, sf_version=self.api_version)
 
@@ -133,7 +170,7 @@ class SalesforceClient(HttpClient):
         return [(field['name'], field['type']) for field in object_desc['fields']
                 if self.is_bulk_supported_field(field)]
 
-    @backoff.on_exception(backoff.expo, SalesforceClientException, max_tries=3)
+    @backoff.on_exception(backoff.expo, RETRIED_DESCRIBE_ERRORS, max_tries=3)
     def describe_object_w_complete_metadata(self, sf_object: str) -> dict[str, Any]:
         salesforce_type = SFType(sf_object, self.sessionId, self.host, sf_version=self.api_version)
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -5,6 +5,7 @@ Created on 12. 11. 2018
 '''
 import contextlib
 import json
+import logging
 import socket
 import tempfile
 import threading
@@ -64,7 +65,11 @@ class LocalHttpServer:
                 continue
             self.connection_count += 1
             with contextlib.closing(connection):
-                connection.settimeout(0.5)
+                # Generous, to match the client's own timeout=5. A recv() timing out on a loaded runner would look
+                # like a dropped connection to the client and fail the 429 test as if it were a product bug. Nothing
+                # waits on this in the happy path, so the headroom costs no test time. The listening socket keeps its
+                # short accept timeout - the serve loop just continues on it.
+                connection.settimeout(5)
                 try:
                     connection.recv(65536)
                     if self._response is not None:
@@ -108,8 +113,19 @@ class TestDroppedConnectionRetries(unittest.TestCase):
             os.makedirs(os.path.join(data_dir, 'out', 'tables'))
             with open(os.path.join(data_dir, 'config.json'), 'w', encoding='utf-8') as config_file:
                 json.dump({'parameters': parameters}, config_file)
-            with mock.patch.dict(os.environ, {'KBC_DATADIR': data_dir}):
-                yield Component()
+            # ComponentBase.__init__ adds root log handlers without removing the ones already there, so a second
+            # Component() in-process leaves the root logger with a duplicate stderr handler and every retry warning
+            # emitted afterwards is printed twice - which reads as a larger retry budget than the code actually has.
+            # Clearing before construction (not just restoring afterwards) is what keeps the counts honest while the
+            # warnings are emitted; the originals go back in the finally.
+            root_logger = logging.getLogger()
+            original_handlers = root_logger.handlers[:]
+            root_logger.handlers.clear()
+            try:
+                with mock.patch.dict(os.environ, {'KBC_DATADIR': data_dir}):
+                    yield Component()
+            finally:
+                root_logger.handlers[:] = original_handlers
 
     def test_transport_retries_are_mounted_on_the_salesforce_session(self):
         session = requests.Session()
@@ -119,6 +135,10 @@ class TestDroppedConnectionRetries(unittest.TestCase):
         retries = session.get_adapter('https://example.my.salesforce.com/').max_retries
         self.assertEqual(3, retries.connect)
         self.assertEqual(3, retries.read)
+        # Both socket tests below patch this factor away, so nothing else holds the documented timing: at 1 the
+        # sleeps are 0, 2 and 4 s, about 6 s added to a request that ultimately fails. Raising it would silently
+        # multiply that on every failing request, including the sync-action paths a user waits on.
+        self.assertEqual(1, retries.backoff_factor)
         # HTTP responses must never be retried - every response the component already handled is passed through.
         # total=None is what makes Retry.is_retry() False for every status, so pin it rather than leave it
         # incidental; status/status_forcelist keep it False even if total is ever given a number.
@@ -165,7 +185,6 @@ class TestDroppedConnectionRetries(unittest.TestCase):
             with self.assertRaises(RequestsConnectionError):
                 comp._login_to_salesforce(comp.configuration.parameters)
 
-        # The two stacked retry decorators must not multiply attempts - each catches only its own exception type.
         self.assertEqual(3, from_security_token.call_count)
 
     @mock.patch('salesforce.client.TRANSPORT_RETRY_BACKOFF_FACTOR', 0)
@@ -180,6 +199,22 @@ class TestDroppedConnectionRetries(unittest.TestCase):
 
         # One initial attempt plus the three configured retries.
         self.assertEqual(4, server.connection_count)
+
+    @mock.patch('salesforce.client.TRANSPORT_RETRY_BACKOFF_FACTOR', 0)
+    def test_adapter_does_not_resend_a_post_that_already_reached_the_server(self):
+        server = LocalHttpServer()
+        self.addCleanup(server.close)
+        session = requests.Session()
+        SalesforceClient._mount_transport_retries(session)
+
+        with self.assertRaises(RequestsConnectionError):
+            session.post(server.url, data=b'{}', timeout=5)
+
+        # The load-bearing invariant of this change, asserted behaviourally rather than through allowed_methods:
+        # the server read the request and then dropped the connection, and urllib3's read branch re-raises
+        # immediately for POST. So a Bulk 2.0 job-creation POST is never sent twice and cannot create a second bulk
+        # job. Same server, same drop, over GET takes 4 connections - see the test above.
+        self.assertEqual(1, server.connection_count)
 
     @mock.patch('salesforce.client.TRANSPORT_RETRY_BACKOFF_FACTOR', 0)
     def test_adapter_passes_a_429_with_retry_after_straight_through(self):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -3,12 +3,23 @@ Created on 12. 11. 2018
 
 @author: esner
 '''
+import contextlib
+import json
+import tempfile
 import unittest
 import mock
 import os
+import requests
 from freezegun import freeze_time
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from component import Component
+from salesforce.client import SalesforceClient
+
+# What requests raises when Salesforce closes the connection without sending a response.
+DROPPED_CONNECTION = RequestsConnectionError(
+    "('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))"
+)
 
 
 class TestComponent(unittest.TestCase):
@@ -21,6 +32,78 @@ class TestComponent(unittest.TestCase):
         with self.assertRaises(ValueError):
             comp = Component()
             comp.run()
+
+
+class TestDroppedConnectionRetries(unittest.TestCase):
+    """A dropped connection is retried instead of killing the job, and still fails the job when it persists."""
+
+    @staticmethod
+    def _build_client(session=None):
+        simple_client = mock.MagicMock()
+        simple_client.base_url = 'https://example.my.salesforce.com/services/data/v52.0/'
+        simple_client.session_id = 'dummy-session-id'
+        simple_client.session = session if session is not None else requests.Session()
+        return SalesforceClient(simple_client=simple_client, api_version='52.0')
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _build_component(parameters):
+        with tempfile.TemporaryDirectory() as data_dir:
+            os.makedirs(os.path.join(data_dir, 'out', 'tables'))
+            with open(os.path.join(data_dir, 'config.json'), 'w', encoding='utf-8') as config_file:
+                json.dump({'parameters': parameters}, config_file)
+            with mock.patch.dict(os.environ, {'KBC_DATADIR': data_dir}):
+                yield Component()
+
+    def test_transport_retries_are_mounted_on_the_salesforce_session(self):
+        session = requests.Session()
+
+        self._build_client(session)
+
+        retries = session.get_adapter('https://example.my.salesforce.com/').max_retries
+        self.assertEqual(3, retries.connect)
+        self.assertEqual(3, retries.read)
+        # HTTP responses must never be retried - every response the component already handled is passed through.
+        self.assertEqual(0, retries.status)
+        self.assertFalse(retries.status_forcelist)
+        # Only idempotent methods are retried, so no request with a side effect is ever re-sent.
+        self.assertNotIn('POST', retries.allowed_methods)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch('salesforce.client.SFType')
+    def test_describe_object_retries_dropped_connection_then_reraises(self, sf_type, _sleep):
+        sf_type.return_value.describe.side_effect = DROPPED_CONNECTION
+        client = self._build_client()
+
+        with self.assertRaises(RequestsConnectionError):
+            client.describe_object('Account')
+
+        self.assertEqual(3, sf_type.return_value.describe.call_count)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch('salesforce.client.SFType')
+    def test_describe_object_succeeds_after_a_dropped_connection(self, sf_type, _sleep):
+        sf_type.return_value.describe.side_effect = [
+            DROPPED_CONNECTION,
+            {'fields': [{'name': 'Id', 'type': 'id'}, {'name': 'Photo', 'type': 'base64'}]},
+        ]
+        client = self._build_client()
+
+        self.assertEqual(['Id'], client.describe_object('Account'))
+        self.assertEqual(2, sf_type.return_value.describe.call_count)
+
+    @mock.patch('time.sleep', return_value=None)
+    @mock.patch('component.SalesforceClient.from_security_token')
+    def test_login_retries_dropped_connection_then_reraises(self, from_security_token, _sleep):
+        from_security_token.side_effect = DROPPED_CONNECTION
+        parameters = {'login_method': 'security_token', 'username': 'user',
+                      '#password': 'password', '#security_token': 'token'}
+
+        with self._build_component(parameters) as comp:
+            with self.assertRaises(RequestsConnectionError):
+                comp._login_to_salesforce(comp.configuration.parameters)
+
+        self.assertEqual(3, from_security_token.call_count)
 
 
 if __name__ == "__main__":

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -5,7 +5,9 @@ Created on 12. 11. 2018
 '''
 import contextlib
 import json
+import socket
 import tempfile
+import threading
 import unittest
 import mock
 import os
@@ -16,10 +18,64 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from component import Component
 from salesforce.client import SalesforceClient
 
-# What requests raises when Salesforce closes the connection without sending a response.
-DROPPED_CONNECTION = RequestsConnectionError(
-    "('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))"
-)
+
+def dropped_connection() -> RequestsConnectionError:
+    """A fresh instance of what requests raises when Salesforce closes the connection without responding.
+
+    Built per call on purpose: one shared instance would be raised repeatedly and accumulate __traceback__
+    frames across retries and across tests.
+    """
+    return RequestsConnectionError(
+        "('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))"
+    )
+
+
+def raise_dropped_connection(*_args, **_kwargs):
+    """mock side_effect raising a fresh dropped_connection() on every call."""
+    raise dropped_connection()
+
+
+class LocalHttpServer:
+    """A local TCP server used to exercise the mounted retry adapter against real socket behaviour.
+
+    With no response configured it accepts, reads the request and closes without answering - the failure this
+    PR is about. With one configured it replies with those exact bytes. Binds to port 0 and runs on a daemon
+    thread with short timeouts so it cannot hang or collide with anything in CI.
+    """
+
+    def __init__(self, response: bytes = None) -> None:
+        self._response = response
+        self.connection_count = 0
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.bind(('127.0.0.1', 0))
+        self._socket.listen(8)
+        self._socket.settimeout(0.5)
+        self.url = f'http://127.0.0.1:{self._socket.getsockname()[1]}/'
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            try:
+                connection, _ = self._socket.accept()
+            except OSError:
+                continue
+            self.connection_count += 1
+            with contextlib.closing(connection):
+                connection.settimeout(0.5)
+                try:
+                    connection.recv(65536)
+                    if self._response is not None:
+                        connection.sendall(self._response)
+                except OSError:
+                    pass
+
+    def close(self) -> None:
+        self._stop.set()
+        self._socket.close()
+        self._thread.join(timeout=2)
 
 
 class TestComponent(unittest.TestCase):
@@ -64,15 +120,21 @@ class TestDroppedConnectionRetries(unittest.TestCase):
         self.assertEqual(3, retries.connect)
         self.assertEqual(3, retries.read)
         # HTTP responses must never be retried - every response the component already handled is passed through.
+        # total=None is what makes Retry.is_retry() False for every status, so pin it rather than leave it
+        # incidental; status/status_forcelist keep it False even if total is ever given a number.
+        self.assertIsNone(retries.total)
         self.assertEqual(0, retries.status)
         self.assertFalse(retries.status_forcelist)
-        # Only idempotent methods are retried, so no request with a side effect is ever re-sent.
+        self.assertFalse(retries.respect_retry_after_header)
+        # allowed_methods gates urllib3's read branch only, so this proves POST is not retried *after* the request
+        # went out - not that POST is never retried. Connect-phase failures, which urllib3 raises only when the
+        # server provably never received the request, are retried for every method.
         self.assertNotIn('POST', retries.allowed_methods)
 
     @mock.patch('time.sleep', return_value=None)
     @mock.patch('salesforce.client.SFType')
     def test_describe_object_retries_dropped_connection_then_reraises(self, sf_type, _sleep):
-        sf_type.return_value.describe.side_effect = DROPPED_CONNECTION
+        sf_type.return_value.describe.side_effect = raise_dropped_connection
         client = self._build_client()
 
         with self.assertRaises(RequestsConnectionError):
@@ -84,7 +146,7 @@ class TestDroppedConnectionRetries(unittest.TestCase):
     @mock.patch('salesforce.client.SFType')
     def test_describe_object_succeeds_after_a_dropped_connection(self, sf_type, _sleep):
         sf_type.return_value.describe.side_effect = [
-            DROPPED_CONNECTION,
+            dropped_connection(),
             {'fields': [{'name': 'Id', 'type': 'id'}, {'name': 'Photo', 'type': 'base64'}]},
         ]
         client = self._build_client()
@@ -95,7 +157,7 @@ class TestDroppedConnectionRetries(unittest.TestCase):
     @mock.patch('time.sleep', return_value=None)
     @mock.patch('component.SalesforceClient.from_security_token')
     def test_login_retries_dropped_connection_then_reraises(self, from_security_token, _sleep):
-        from_security_token.side_effect = DROPPED_CONNECTION
+        from_security_token.side_effect = raise_dropped_connection
         parameters = {'login_method': 'security_token', 'username': 'user',
                       '#password': 'password', '#security_token': 'token'}
 
@@ -103,7 +165,35 @@ class TestDroppedConnectionRetries(unittest.TestCase):
             with self.assertRaises(RequestsConnectionError):
                 comp._login_to_salesforce(comp.configuration.parameters)
 
+        # The two stacked retry decorators must not multiply attempts - each catches only its own exception type.
         self.assertEqual(3, from_security_token.call_count)
+
+    @mock.patch('salesforce.client.TRANSPORT_RETRY_BACKOFF_FACTOR', 0)
+    def test_adapter_retries_a_real_dropped_connection_and_still_raises_connection_error(self):
+        server = LocalHttpServer()
+        self.addCleanup(server.close)
+        session = requests.Session()
+        SalesforceClient._mount_transport_retries(session)
+
+        with self.assertRaises(RequestsConnectionError):
+            session.get(server.url, timeout=5)
+
+        # One initial attempt plus the three configured retries.
+        self.assertEqual(4, server.connection_count)
+
+    @mock.patch('salesforce.client.TRANSPORT_RETRY_BACKOFF_FACTOR', 0)
+    def test_adapter_passes_a_429_with_retry_after_straight_through(self):
+        server = LocalHttpServer(
+            response=b'HTTP/1.1 429 Too Many Requests\r\nRetry-After: 1\r\nContent-Length: 0\r\n\r\n'
+        )
+        self.addCleanup(server.close)
+        session = requests.Session()
+        SalesforceClient._mount_transport_retries(session)
+
+        response = session.get(server.url, timeout=5)
+
+        self.assertEqual(429, response.status_code)
+        self.assertEqual(1, server.connection_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds defensive handling for an unhandled `requests.exceptions.ConnectionError` observed in production for `kds-team.ex-salesforce-v2`. No change to the component's behaviour on inputs that already worked.

## Root cause

Salesforce closed the connection without sending a response. `requests` surfaces that as

```
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

Nothing on the path catches it, so it falls through to the catch-all in `src/component.py` (`except Exception: logging.exception(exc); exit(2)`) and the job dies with an opaque **internal error**. Classified as **transient**: 3 unrelated jobs failed with the byte-for-byte identical error inside a 36-second window, i.e. an upstream blip that a retry would have ridden out.

Two reasons it slips through the retry machinery the component already has:

* the `describe_object*` methods catch the **built-in** `ConnectionError`, and `requests.exceptions.ConnectionError` is not a subclass of it;
* `SalesforceClient` is constructed with `max_retries=MAX_RETRIES`, but that only configures `keboola.http_client`'s own session — every real Salesforce request goes through the `simple_salesforce` session, which had no retry adapter at all.

## Fix

A bounded retry for that one transport failure, in the three places it can reach the component. All additive:

1. **`SalesforceClient._mount_transport_retries`** — mounts a `requests` `HTTPAdapter` on the `simple_salesforce` session that retries **only when no response arrived** (`total=None`, `connect=3`, `read=3`, `status=0`, no `status_forcelist`, `other=0`, `respect_retry_after_header=False`, urllib3's default idempotent-only `allowed_methods`). Coverage is the **pre-response phase inside `HTTPAdapter.send`** — `test_query` and the Bulk 2.0 GETs (`wait_for_job`, `download_job_data`) up to the point the response line arrives.
2. **`describe_object` / `describe_object_w_metadata` / `describe_object_w_complete_metadata`** — `requests.exceptions.ConnectionError` added to their existing `backoff` predicates. These talk through `SFType`, which builds its own session, so (1) does not cover them.
3. **`_login_to_salesforce`** — `RequestsConnectionError` added to the exception tuple of the pre-existing retry decorator, since login runs before the client session exists: `@retry((SalesforceAuthenticationFailed, RequestsConnectionError), tries=3, delay=5)`. One decorator over both types, not two stacked ones — nesting multiplies the attempt budget to `tries × tries`, because an inner run ending in the outer decorator's exception is re-entered with a fresh inner budget (measured over mixed connection/authentication sequences: **9** attempts whichever way they are nested, up to **40 s** of sleep in the worst ordering). The combined form has a hard **3-attempt** cap and gives the pre-existing authentication path byte-identical timing to `main` — 3 attempts, sleeps `[5, 5]`, same logger. A transport failure still propagates unchanged, since `get_salesforce_client` converts only `SalesforceAuthenticationFailed` into a `UserException`.

Deliberately **not** retried: the Bulk job-creation `POST` once it has reached Salesforce. Re-sending it could create a second bulk job and duplicate output slices. Salesforce API-level transient error codes during bulk download are a different error class and are already the subject of #11.

Also deliberately **not** retried: a bulk result download dropped **mid-body**. That surfaces out of `iter_content` as `requests.exceptions.ChunkedEncodingError`, not `ConnectionError`, and leaves a partial CSV in the output path. That is pre-existing behaviour and is unchanged by this PR — retrying it would mean re-downloading into a file that already has bytes in it, i.e. exactly the output-affecting change this PR stays clear of. Worth a follow-up issue; the alert this PR targets is the pre-response case ("closed connection *without response*").

## Behaviour impact: none — defensive-only

* Happy path unchanged; no outputs, transforms, schema, or config semantics touched.
* **No HTTP response is ever retried.** Three settings carry that invariant together: `total=None` makes `Retry.is_retry()` short-circuit to `False` for every status, the empty `status_forcelist` with `status=0` keeps it `False` if `total` is ever given a number, and `respect_retry_after_header=False` closes the remaining path where a 413/429/503 carrying `Retry-After` could be acted on. So 4xx/5xx and Salesforce error payloads still reach `simple_salesforce`'s error handler on the first response and surface as the same `SalesforceError` / `SalesforceMalformedRequest` / `SalesforceExpiredSession` as before. Verified against a local server: a `429` with `Retry-After: 1` is returned as a `429` **response object** after exactly one connection.
* **No request that actually reached Salesforce is re-sent.** `allowed_methods` gates only urllib3's *read* branch — a `RemoteDisconnected` *after* the request went out re-raises immediately for `POST`, exactly as today. Connect-phase errors (`ConnectTimeoutError`, and `NewConnectionError` which subclasses it — DNS failure, refused connection) are retried for **every** method, but urllib3 only classifies a failure there when the server provably never received the request, so no side effect can be duplicated.
* **Proxy support is unaffected.** Proxies are resolved per-request by `Session.merge_environment_settings` from `HTTPS_PROXY` and passed into `adapter.send(...)`; a stock adapter with only `max_retries` customised handles them identically.
* **A persistent failure still fails the job identically, and still alerts.** `backoff` and `retry` re-raise the original exception after the last attempt, and an exhausted adapter retry comes back out of `HTTPAdapter.send` as `requests.exceptions.ConnectionError` — same exception type, same exit code 2. The message shape does change, because urllib3 raises `MaxRetryError` and requests re-wraps it:

  ```
  HTTPSConnectionPool(...): Max retries exceeded with url: … (Caused by ProtocolError('Connection aborted.', RemoteDisconnected(...)))
  ```

  That does not affect alerting: the failure monitor matches on log level plus service plus component — `status:(critical OR emergency)`, the job-queue-runner service, and this component's id — not on the message text. Checked before merge, since a change that silenced a persistent failure would be the worst possible regression here.
* **Added latency on a request that ultimately fails.** urllib3 does not wait before the first retry, so at `backoff_factor=1` the sleeps are 0, 2 and 4 s — about 6 s, measured. This applies to the requests that go through the mounted session; the `describe_object*` calls do not, so their `backoff.expo` waits never stack on top of it. On the interactive sync-action login path the worst case is 10 s of added sleep (2 retries × 5 s) — the same delay `main` already spends on an authentication input that can never work, now also spent on a permanently unreachable one.
* The pre-existing `except ConnectionError` blocks still bind the **built-in** exception (the new import is aliased), so their behaviour is untouched.

## Evidence

Datadog failure monitor for this component: 3 occurrences, all `('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))`, container exit code 2.

## Tests

`python -m unittest discover` green — **8 passed** in ~1.6 s, `flake8 --config=flake8.cfg src` clean. CI runs both inside the built image (python 3.13).

The pre-existing test is untouched (no assertions modified or deleted). Seven regression tests added:

* **behavioural, against a real socket** — a stdlib `socket` server on `127.0.0.1:0` that accepts, reads and closes without responding: asserts the server sees **4** connections and that the exception reaching the caller is still `requests.exceptions.ConnectionError`;
* **behavioural** — the same server, same drop, over `POST`: asserts exactly **1** connection, so the load-bearing "no request that actually reached Salesforce is re-sent" invariant is pinned by behaviour and not only by the `allowed_methods` configuration. A bulk job-creation `POST` therefore cannot be sent twice;
* **behavioural** — the same server answering `429` with `Retry-After: 1`: asserts exactly **1** connection and a `429` response object, i.e. no response is retried;
* the mounted adapter's configuration is pinned (`total` is `None`, `status=0`, empty `status_forcelist`, `respect_retry_after_header` false, `backoff_factor` 1, `POST` not in `allowed_methods`) — `backoff_factor` included because both socket tests patch it away, so nothing else holds the documented 0/2/4 s timing;
* `describe_object` retries a dropped connection 3 times and then **re-raises the original exception**;
* `describe_object` returns the normal result when the connection drops once and then succeeds;
* `_login_to_salesforce` retries a dropped connection 3 times and then **re-raises the original exception**, pinning the retry decorator's hard 3-attempt cap.

Hermetic and fast: stdlib only, no new dependency, port 0, sockets always closed in cleanup, and the backoff factor patched to `0` so there is no real wait. The socket server's per-connection timeout matches the client's own `timeout=5` so a loaded runner cannot turn a slow `recv` into a fake dropped connection; the listening socket keeps a short accept timeout, which the serve loop simply continues on. The `Component()` test helper also clears and restores the root log handlers, so retry-warning counts in CI output are not doubled by a leaked duplicate handler.


