### PR TITLE
Defensive fix: retry a bulk result page Salesforce truncated mid-transfer

### DIFF
--- a/src/salesforce/client.py
+++ b/src/salesforce/client.py
@@ -61,10 +61,10 @@ RETRIED_DESCRIBE_ERRORS = (SalesforceClientException, RequestsConnectionError)
 # the transport retries mounted in _mount_transport_retries provably cannot see it. Nothing else retries it, so a
 # single truncated page killed the whole job with an opaque internal error. Only this one exception is retried:
 # it can only be raised while reading a response body, never in place of a response the component already handles.
-DOWNLOAD_RESULT_MAX_TRIES = 3
-# One delay per retry, so three attempts wait 2 s and then 4 s. A page that keeps failing costs 6 s more
+# One delay per retry, so three attempts in total wait 2 s and then 4 s. A page that keeps failing costs 6 s more
 # than it used to before the job dies with the same exception it dies with today.
 DOWNLOAD_RESULT_RETRY_DELAYS = (2, 4)
+DOWNLOAD_RESULT_MAX_TRIES = len(DOWNLOAD_RESULT_RETRY_DELAYS) + 1
 
 
 class SalesforceBulk2(SFBulk2Type):
@@ -105,25 +105,24 @@ class SalesforceBulk2(SFBulk2Type):
         a failed attempt is removed before the next one runs - `path` therefore holds exactly the pages it held
         before the attempt, and a retry can never add a duplicate or partial slice.
 
-        The final attempt is deliberately left alone: it re-raises the original exception without cleaning up,
-        so a download that keeps failing ends with the very same exception and the very same directory contents
-        as before this method existed. Only ChunkedEncodingError is retried, and it can only be raised while a
-        response body is being read - every response the component already handled, error responses included,
-        is passed through untouched.
+        The last attempt is the unwrapped call the loop below used to make on its own, so a download that keeps
+        failing ends with the very same exception and the very same directory contents as before this method
+        existed. Only ChunkedEncodingError is retried, and it can only be raised while a response body is being
+        read - every response the component already handled, error responses included, is passed through
+        untouched.
         """
-        for attempt in range(1, DOWNLOAD_RESULT_MAX_TRIES + 1):
+        for attempt, delay in enumerate(DOWNLOAD_RESULT_RETRY_DELAYS, start=1):
             files_before = self._list_files(path)
             try:
                 return self._client.download_job_data(path, job_id, locator, max_records)
             except ChunkedEncodingError as e:
-                if attempt == DOWNLOAD_RESULT_MAX_TRIES:
-                    raise
                 self._discard_files_created_since(path, files_before)
-                delay = DOWNLOAD_RESULT_RETRY_DELAYS[attempt - 1]
                 logging.warning(f"Salesforce ended the result download prematurely ({e}). Discarded the partial "
                                 f"page and retrying in {delay} s "
                                 f"(attempt {attempt + 1} of {DOWNLOAD_RESULT_MAX_TRIES}).")
                 time.sleep(delay)
+
+        return self._client.download_job_data(path, job_id, locator, max_records)
 
     @staticmethod
     def _list_files(path: str) -> set[str]:

--- a/src/salesforce/client.py
+++ b/src/salesforce/client.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import time
 from collections import OrderedDict
 from typing import Any, Iterator
 from urllib.parse import urlparse
@@ -9,6 +10,7 @@ import backoff
 import requests
 from keboola.http_client import HttpClient
 from requests.adapters import HTTPAdapter, Retry
+from requests.exceptions import ChunkedEncodingError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from simple_salesforce.api import Salesforce, SFType
 from simple_salesforce.bulk2 import ColumnDelimiter, LineEnding, Operation, QueryResult, SFBulk2Type
@@ -53,6 +55,17 @@ class SalesforceClientException(Exception):
 # After max_tries the original exception is re-raised unchanged.
 RETRIED_DESCRIBE_ERRORS = (SalesforceClientException, RequestsConnectionError)
 
+# Retried by SalesforceBulk2._download_result_page. Result pages are streamed straight to disk, so a body that
+# Salesforce truncates mid-transfer surfaces out of iter_content as requests.exceptions.ChunkedEncodingError
+# ("Response ended prematurely") - raised after HTTPAdapter.send has already returned its response, which is why
+# the transport retries mounted in _mount_transport_retries provably cannot see it. Nothing else retries it, so a
+# single truncated page killed the whole job with an opaque internal error. Only this one exception is retried:
+# it can only be raised while reading a response body, never in place of a response the component already handles.
+DOWNLOAD_RESULT_MAX_TRIES = 3
+# One delay per retry, so three attempts wait 2 s and then 4 s. A page that keeps failing costs 6 s more
+# than it used to before the job dies with the same exception it dies with today.
+DOWNLOAD_RESULT_RETRY_DELAYS = (2, 4)
+
 
 class SalesforceBulk2(SFBulk2Type):
     def __init__(self, sf_client, object_name: str):
@@ -78,10 +91,60 @@ class SalesforceBulk2(SFBulk2Type):
         while locator:
             if locator == "INIT":
                 locator = ""
-            result = self._client.download_job_data(path, job_id, locator, max_records)
+            result = self._download_result_page(path, job_id, locator, max_records)
             locator = result["locator"]
             results.append(result)
         return results
+
+    def _download_result_page(self, path: str, job_id: str, locator: str, max_records: int) -> QueryResult:
+        """Downloads one page of bulk results, retrying a body that Salesforce truncated mid-transfer.
+
+        Re-requesting a page is safe: the results endpoint reads a completed job's stored output, so the same
+        locator returns the same records. simple_salesforce streams each page into its own uniquely named
+        temporary file inside `path` and leaves that file behind when the stream dies, so the truncated file of
+        a failed attempt is removed before the next one runs - `path` therefore holds exactly the pages it held
+        before the attempt, and a retry can never add a duplicate or partial slice.
+
+        The final attempt is deliberately left alone: it re-raises the original exception without cleaning up,
+        so a download that keeps failing ends with the very same exception and the very same directory contents
+        as before this method existed. Only ChunkedEncodingError is retried, and it can only be raised while a
+        response body is being read - every response the component already handled, error responses included,
+        is passed through untouched.
+        """
+        for attempt in range(1, DOWNLOAD_RESULT_MAX_TRIES + 1):
+            files_before = self._list_files(path)
+            try:
+                return self._client.download_job_data(path, job_id, locator, max_records)
+            except ChunkedEncodingError as e:
+                if attempt == DOWNLOAD_RESULT_MAX_TRIES:
+                    raise
+                self._discard_files_created_since(path, files_before)
+                delay = DOWNLOAD_RESULT_RETRY_DELAYS[attempt - 1]
+                logging.warning(f"Salesforce ended the result download prematurely ({e}). Discarded the partial "
+                                f"page and retrying in {delay} s "
+                                f"(attempt {attempt + 1} of {DOWNLOAD_RESULT_MAX_TRIES}).")
+                time.sleep(delay)
+
+    @staticmethod
+    def _list_files(path: str) -> set[str]:
+        """Names currently in the download directory. An unreadable directory yields nothing to clean up."""
+        try:
+            return set(os.listdir(path))
+        except OSError:
+            return set()
+
+    @classmethod
+    def _discard_files_created_since(cls, path: str, files_before: set[str]) -> None:
+        """Removes only what the failed attempt added, never a page that was downloaded successfully.
+
+        Cleanup must never replace the download failure with an error of its own, so anything that goes wrong
+        removing a file is logged and swallowed; the caller still sees the ChunkedEncodingError.
+        """
+        for name in sorted(cls._list_files(path) - files_before):
+            try:
+                os.remove(os.path.join(path, name))
+            except OSError as remove_error:
+                logging.warning(f"Could not remove the partial result file {name}: {remove_error}.")
 
 
 class SalesforceClient(HttpClient):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -48,6 +48,16 @@ def truncated_result_page() -> ChunkedEncodingError:
     return ChunkedEncodingError(ProtocolError("Response ended prematurely"))
 
 
+def raise_truncated_result_page(*_args, **_kwargs):
+    """mock side_effect raising a fresh truncated_result_page() on every call.
+
+    A single shared instance handed to side_effect would be re-raised on every retry and accumulate
+    __traceback__ frames across them, so each attempt gets its own - the same reason
+    raise_dropped_connection exists.
+    """
+    raise truncated_result_page()
+
+
 class LocalHttpServer:
     """A local TCP server used to exercise the mounted retry adapter against real socket behaviour.
 
@@ -271,7 +281,7 @@ class TestTruncatedResultPageRetries(unittest.TestCase):
     @mock.patch('time.sleep', return_value=None)
     def test_truncated_page_is_retried_then_reraises(self, _sleep):
         bulk2 = self._build_bulk2()
-        bulk2._client.download_job_data.side_effect = truncated_result_page()
+        bulk2._client.download_job_data.side_effect = raise_truncated_result_page
 
         with tempfile.TemporaryDirectory() as path:
             with self.assertRaises(ChunkedEncodingError):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -16,8 +16,11 @@ import requests
 from freezegun import freeze_time
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
+from requests.exceptions import ChunkedEncodingError
+from urllib3.exceptions import ProtocolError
+
 from component import Component
-from salesforce.client import SalesforceClient
+from salesforce.client import DOWNLOAD_RESULT_MAX_TRIES, SalesforceBulk2, SalesforceClient
 
 
 def dropped_connection() -> RequestsConnectionError:
@@ -34,6 +37,15 @@ def dropped_connection() -> RequestsConnectionError:
 def raise_dropped_connection(*_args, **_kwargs):
     """mock side_effect raising a fresh dropped_connection() on every call."""
     raise dropped_connection()
+
+
+def truncated_result_page() -> ChunkedEncodingError:
+    """What requests raises out of iter_content when Salesforce cuts a result body short.
+
+    Built the way requests builds it - urllib3 raises ProtocolError("Response ended prematurely") while reading
+    the body and requests re-raises it as ChunkedEncodingError - so str() matches the message seen in production.
+    """
+    return ChunkedEncodingError(ProtocolError("Response ended prematurely"))
 
 
 class LocalHttpServer:
@@ -229,6 +241,145 @@ class TestDroppedConnectionRetries(unittest.TestCase):
 
         self.assertEqual(429, response.status_code)
         self.assertEqual(1, server.connection_count)
+
+
+class TestTruncatedResultPageRetries(unittest.TestCase):
+    """A result page Salesforce cut short is retried instead of killing the job, and still fails when it persists.
+
+    The transport retries mounted on the session cannot reach this failure: it is raised while the response body
+    is being read, after HTTPAdapter.send has already handed the response back. These tests pin both halves - the
+    retry works, and the directory the pages are written into never gains a truncated slice because of it.
+    """
+
+    @staticmethod
+    def _build_bulk2() -> SalesforceBulk2:
+        simple_client = mock.MagicMock()
+        simple_client.bulk2_url = 'https://example.my.salesforce.com/services/data/v52.0/jobs/'
+        simple_client.headers = {}
+        simple_client.session = requests.Session()
+        bulk2 = SalesforceBulk2(simple_client, 'Opportunity')
+        bulk2._client = mock.MagicMock()
+        return bulk2
+
+    @staticmethod
+    def _page(path: str, contents: bytes, locator: str = '', number_of_records: int = 1) -> dict:
+        """Writes a page file the way simple_salesforce does - a fresh temp file inside the download directory."""
+        with tempfile.NamedTemporaryFile('wb', dir=path, suffix='.csv', delete=False) as page_file:
+            page_file.write(contents)
+        return {'locator': locator, 'number_of_records': number_of_records, 'file': page_file.name}
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_truncated_page_is_retried_then_reraises(self, _sleep):
+        bulk2 = self._build_bulk2()
+        bulk2._client.download_job_data.side_effect = truncated_result_page()
+
+        with tempfile.TemporaryDirectory() as path:
+            with self.assertRaises(ChunkedEncodingError):
+                bulk2._download_result_page(path, 'job-id', '', 50000)
+
+        self.assertEqual(DOWNLOAD_RESULT_MAX_TRIES, bulk2._client.download_job_data.call_count)
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_truncated_page_succeeds_after_a_retry(self, _sleep):
+        bulk2 = self._build_bulk2()
+
+        with tempfile.TemporaryDirectory() as path:
+            expected = {'locator': '', 'number_of_records': 2, 'file': 'page.csv'}
+            bulk2._client.download_job_data.side_effect = [truncated_result_page(), expected]
+
+            self.assertEqual(expected, bulk2._download_result_page(path, 'job-id', '', 50000))
+
+        self.assertEqual(2, bulk2._client.download_job_data.call_count)
+        # Every attempt asks for the same page. Re-requesting a locator is what makes the retry safe, so a change
+        # that started advancing the locator between attempts - and silently skipped records - must fail here.
+        self.assertEqual([mock.call(mock.ANY, 'job-id', '', 50000)] * 2,
+                         bulk2._client.download_job_data.call_args_list)
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_the_partial_file_of_a_retried_attempt_is_discarded(self, _sleep):
+        bulk2 = self._build_bulk2()
+
+        with tempfile.TemporaryDirectory() as path:
+            already_downloaded = self._page(path, b'Id\n1\n')
+
+            def truncate_then_succeed(page_path, *_args, **_kwargs):
+                if bulk2._client.download_job_data.call_count == 1:
+                    self._page(page_path, b'Id\n2')  # the half-written file simple_salesforce leaves behind
+                    raise truncated_result_page()
+                return self._page(page_path, b'Id\n2\n3\n')
+
+            bulk2._client.download_job_data.side_effect = truncate_then_succeed
+
+            result = bulk2._download_result_page(path, 'job-id', '', 50000)
+
+            # The page downloaded before the failure survives, the truncated one is gone, and the retry's own file
+            # is the only thing added - so the sliced output directory can never gain a partial or duplicate slice.
+            expected = sorted([os.path.basename(already_downloaded['file']), os.path.basename(result['file'])])
+            self.assertEqual(expected, sorted(os.listdir(path)))
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_the_final_attempt_leaves_the_directory_exactly_as_it_used_to(self, _sleep):
+        """The give-up path is untouched: same exception, and the last attempt's file is still left behind.
+
+        This is what makes the change defensive rather than behavioural - a download that keeps failing ends in
+        precisely the state it ended in before the retry existed.
+        """
+        bulk2 = self._build_bulk2()
+
+        with tempfile.TemporaryDirectory() as path:
+            def always_truncate(page_path, *_args, **_kwargs):
+                self._page(page_path, b'Id\n2')
+                raise truncated_result_page()
+
+            bulk2._client.download_job_data.side_effect = always_truncate
+
+            with self.assertRaises(ChunkedEncodingError):
+                bulk2._download_result_page(path, 'job-id', '', 50000)
+
+            # Only the last attempt's file remains: the two before it were cleaned up ahead of their retries.
+            self.assertEqual(1, len(os.listdir(path)))
+
+    def test_a_page_that_downloads_first_time_is_requested_once_and_never_waits(self):
+        """The happy path is byte-for-byte what it was: one call, no cleanup, no sleep."""
+        bulk2 = self._build_bulk2()
+
+        with tempfile.TemporaryDirectory() as path:
+            expected = self._page(path, b'Id\n1\n')
+            bulk2._client.download_job_data.return_value = expected
+
+            with mock.patch('time.sleep') as sleep:
+                self.assertEqual(expected, bulk2._download_result_page(path, 'job-id', '', 50000))
+
+            sleep.assert_not_called()
+            self.assertEqual(1, bulk2._client.download_job_data.call_count)
+            self.assertEqual([os.path.basename(expected['file'])], os.listdir(path))
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_download_pages_through_the_retrying_helper(self, _sleep):
+        """The loop that walks the locators goes through the retry, so a mid-download truncation is covered."""
+        bulk2 = self._build_bulk2()
+
+        with tempfile.TemporaryDirectory() as path:
+            first = {'locator': 'page-2', 'number_of_records': 1, 'file': 'a.csv'}
+            second = {'locator': '', 'number_of_records': 1, 'file': 'b.csv'}
+            bulk2._client.download_job_data.side_effect = [first, truncated_result_page(), second]
+            bulk2._client.create_job.return_value = {'id': 'job-id'}
+
+            results = bulk2.download('SELECT Id FROM Opportunity', path)
+
+        self.assertEqual([first, second], results)
+        self.assertEqual(3, bulk2._client.download_job_data.call_count)
+
+    def test_an_error_response_is_not_mistaken_for_a_truncated_body(self):
+        """Anything other than a truncated body propagates on the first attempt, unretried and unchanged."""
+        bulk2 = self._build_bulk2()
+        bulk2._client.download_job_data.side_effect = ValueError('malformed response')
+
+        with tempfile.TemporaryDirectory() as path:
+            with self.assertRaises(ValueError):
+                bulk2._download_result_page(path, 'job-id', '', 50000)
+
+        self.assertEqual(1, bulk2._client.download_job_data.call_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What happened

Jobs for `kds-team.ex-salesforce-v2` failed with an opaque internal error (exit code 2,
surfaced to the user as *"Internal Server Error occurred."*) when Salesforce ended a bulk
result download before the response body was complete.

`urllib3` raises `ProtocolError("Response ended prematurely")` while reading the body and
`requests` re-raises it as `requests.exceptions.ChunkedEncodingError`, which had nowhere to
land and fell through to the catch-all handler in `src/component.py`. The run died after
the sliced output directory had been created but before the manifest was written, so the
platform discarded the directory and nothing was loaded.

**Exception caught:** `requests.exceptions.ChunkedEncodingError` — and only that one.

## Why the existing retries did not cover it

`SalesforceClient._mount_transport_retries` mounts a `urllib3` `Retry` on the Salesforce
session, but those retries live inside `HTTPAdapter.send`. A result page is streamed, so
the body is read *after* `send` has already returned its response object — the adapter can
never see the failure. The existing docstring already called this gap out explicitly; this
PR closes it.

## The change

One bounded retry around one call, in `SalesforceBulk2`:

- `_download_result_page` re-requests the **same** `locator` and `max_records` up to three
  times, waiting 2 s then 4 s. Re-requesting is safe: the Bulk 2.0 results endpoint reads a
  completed job's stored output, so the same locator returns the same records.
- `simple_salesforce` streams each page into its own uniquely named temp file inside the
  download directory and leaves that file behind when the stream dies. The truncated file of
  a retried attempt is therefore removed before the next attempt runs, so the sliced output
  directory can never gain a partial or duplicate slice.
- The **final** attempt re-raises the original exception without cleaning up, so a download
  that keeps failing ends with exactly the same exception and exactly the same directory
  contents as it did before this change.
- Cleanup failures are logged and swallowed, so cleanup can never replace the download error
  with an error of its own.

## Behaviour impact: none — defensive-only

- A page that downloads first time takes **one** call, no cleanup and no wait. The success
  path, the outputs, the transforms, the schema and the emitted rows are untouched.
- Only `ChunkedEncodingError` is retried, and it can only be raised while a response body is
  being read — never in place of a response the component already handled. Error responses
  still pass straight through.
- A persistently failing download still fails the job loudly, with the same exception.
- No existing test assertion was changed or removed; the diff on `tests/` is additive.

## Tests

`docker run <image> python -m unittest discover` — **15 tests, OK** (8 pre-existing, all
still green and unmodified, plus 7 new ones), and `flake8 . --config=flake8.cfg` clean —
both run inside the component image, the same way CI runs them.

New coverage:

- a truncated page is retried three times and then re-raises;
- a truncated page that succeeds on the retry returns the page, and every attempt requests
  the same locator (so a change that started advancing it would fail the test);
- the partial file of a retried attempt is discarded while previously downloaded pages survive;
- the give-up path leaves the directory exactly as it used to;
- the happy path makes one call, never sleeps and touches no files;
- `SalesforceBulk2.download` walks its locator loop through the retrying helper;
- a non-truncation error propagates on the first attempt, unretried.

## Evidence

Datadog monitor `97152903` ("… ended with internal error") —
[failure logs](https://app.datadoghq.eu/logs?query=status%3A%28critical%20OR%20emergency%29%20service%3Ajob-queue-runner%20%28%40component%3Akds-team.ex-salesforce-v2%20OR%20%40extra.component%3Akds-team.ex-salesforce-v2%29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
